### PR TITLE
Update avatar_glow.dart with Animation Container Shape as a required …

### DIFF
--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -13,10 +13,12 @@ class AvatarGlow extends StatefulWidget {
   final bool showTwoGlows;
   final Color glowColor;
   final Duration startDelay;
+  final BoxShape shape;
 
   AvatarGlow({
     @required this.endRadius,
     @required this.child,
+    @required this.shape,
     this.duration,
     this.repeat = true,
     this.repeatPauseDuration,
@@ -91,7 +93,7 @@ class _AvatarGlowState extends State<AvatarGlow>
             width: bigDiscAnimation.value,
             child: SizedBox(),
             decoration: BoxDecoration(
-              shape: BoxShape.circle,
+              shape: widget.shape,
               color: (widget.glowColor ?? Colors.white)
                   .withOpacity(alphaAnimation.value),
             ),
@@ -102,7 +104,7 @@ class _AvatarGlowState extends State<AvatarGlow>
                   width: smallDiscAnimation.value,
                   child: SizedBox(),
                   decoration: BoxDecoration(
-                    shape: BoxShape.circle,
+                    shape: widget.shape,
                     color: (widget.glowColor ?? Colors.white)
                         .withOpacity(alphaAnimation.value),
                   ),

--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -18,7 +18,7 @@ class AvatarGlow extends StatefulWidget {
   AvatarGlow({
     @required this.endRadius,
     @required this.child,
-    @required this.shape,
+    this.shape,
     this.duration,
     this.repeat = true,
     this.repeatPauseDuration,
@@ -93,7 +93,7 @@ class _AvatarGlowState extends State<AvatarGlow>
             width: bigDiscAnimation.value,
             child: SizedBox(),
             decoration: BoxDecoration(
-              shape: widget.shape,
+              shape: widget.shape ?? BoxShape.circle,
               color: (widget.glowColor ?? Colors.white)
                   .withOpacity(alphaAnimation.value),
             ),
@@ -104,7 +104,7 @@ class _AvatarGlowState extends State<AvatarGlow>
                   width: smallDiscAnimation.value,
                   child: SizedBox(),
                   decoration: BoxDecoration(
-                    shape: widget.shape,
+                    shape: widget.shape ?? BoxShape.circle,
                     color: (widget.glowColor ?? Colors.white)
                         .withOpacity(alphaAnimation.value),
                   ),


### PR DESCRIPTION
…parameter to allow rectangle and circle shape

This came about because I had a grid view that had square elements. As such a circle background glow wouldn't be the most suitable shape. This way both BoxShapes (circle and rectangle) are available.