### PR TITLE
Fix timer issue in unit tests

### DIFF
--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -59,15 +59,18 @@ class _AvatarGlowState extends State<AvatarGlow>
     end: 0.0,
   ).animate(_controller);
 
-  Future<void> _statusListener(AnimationStatus status) async {
-    if (_controller.status == AnimationStatus.completed) {
-      await Future.delayed(widget.repeatPauseDuration);
-      if (mounted && widget.repeat && widget.animate) {
-        _controller.reset();
-        _controller.forward();
-      }
+  late Timer _repeatPauseTimer;
+
+  late void Function(AnimationStatus status) _statusListener = (_) async {
+    if (controller.status == AnimationStatus.completed) {
+      _repeatPauseTimer = Timer(widget.repeatPauseDuration, () {
+        if (mounted && widget.repeat && widget.animate) {
+          controller.reset();
+          controller.forward();
+        }
+      });
     }
-  }
+  };
 
   @override
   void initState() {
@@ -168,6 +171,7 @@ class _AvatarGlowState extends State<AvatarGlow>
 
   @override
   void dispose() {
+    _repeatPauseTimer.cancel();
     _controller.dispose();
     super.dispose();
   }


### PR DESCRIPTION
Create a Timer variable to store the repeatPauseDuration.

We can then cancel this Timer in the onDispose() method.

This fixes the FakeTimer error when using this Widget in unit tests