### PR TITLE
fix/late timer issue

### DIFF
--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -59,7 +59,7 @@ class _AvatarGlowState extends State<AvatarGlow>
     end: 0.0,
   ).animate(_controller);
 
-  late Timer _repeatPauseTimer;
+  Timer? _repeatPauseTimer;
 
   late void Function(AnimationStatus status) _statusListener = (_) async {
     if (controller.status == AnimationStatus.completed) {
@@ -171,7 +171,7 @@ class _AvatarGlowState extends State<AvatarGlow>
 
   @override
   void dispose() {
-    _repeatPauseTimer.cancel();
+    _repeatPauseTimer?.cancel();
     _controller.dispose();
     super.dispose();
   }

--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -59,15 +59,18 @@ class _AvatarGlowState extends State<AvatarGlow>
     end: 0.0,
   ).animate(_controller);
 
-  Future<void> _statusListener(AnimationStatus status) async {
-    if (_controller.status == AnimationStatus.completed) {
-      await Future.delayed(widget.repeatPauseDuration);
-      if (mounted && widget.repeat && widget.animate) {
-        _controller.reset();
-        _controller.forward();
-      }
+  late Timer _repeatPauseTimer;
+
+  late void Function(AnimationStatus status) _statusListener = (_) async {
+    if (controller.status == AnimationStatus.completed) {
+      _repeatPauseTimer = Timer(widget.repeatPauseDuration, () {
+        if (mounted && widget.repeat && widget.animate) {
+          controller.reset();
+          controller.forward();
+        }
+      });
     }
-  }
+  };
 
   @override
   void initState() {
@@ -168,6 +171,7 @@ class _AvatarGlowState extends State<AvatarGlow>
 
   @override
   void dispose() {
+    _repeatPauseTimer.cancel();
     _controller.dispose();
     super.dispose();
   }

--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -61,12 +61,12 @@ class _AvatarGlowState extends State<AvatarGlow>
 
   Timer? _repeatPauseTimer;
 
-  Future<void> _statusListener(AnimationStatus status) async {
-    if (controller.status == AnimationStatus.completed) {
+  void _statusListener(AnimationStatus status) {
+    if (_controller.status == AnimationStatus.completed) {
       _repeatPauseTimer = Timer(widget.repeatPauseDuration, () {
         if (mounted && widget.repeat && widget.animate) {
-          controller.reset();
-          controller.forward();
+          _controller.reset();
+          _controller.forward();
         }
       });
     }

--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -61,7 +61,7 @@ class _AvatarGlowState extends State<AvatarGlow>
 
   Timer? _repeatPauseTimer;
 
-  late void Function(AnimationStatus status) _statusListener = (_) async {
+  void _statusListener(AnimationStatus status) {
     if (controller.status == AnimationStatus.completed) {
       _repeatPauseTimer = Timer(widget.repeatPauseDuration, () {
         if (mounted && widget.repeat && widget.animate) {
@@ -70,7 +70,7 @@ class _AvatarGlowState extends State<AvatarGlow>
         }
       });
     }
-  };
+  }
 
   @override
   void initState() {

--- a/lib/avatar_glow.dart
+++ b/lib/avatar_glow.dart
@@ -61,7 +61,7 @@ class _AvatarGlowState extends State<AvatarGlow>
 
   Timer? _repeatPauseTimer;
 
-  void _statusListener(AnimationStatus status) {
+  Future<void> _statusListener(AnimationStatus status) async {
     if (controller.status == AnimationStatus.completed) {
       _repeatPauseTimer = Timer(widget.repeatPauseDuration, () {
         if (mounted && widget.repeat && widget.animate) {


### PR DESCRIPTION
Fixing an issue that was introduced in my previous PR.

Disposing of the `AvatarGlow` widget before `_repeatPauseTimer` was initialised would cause a `LateInitializationError ` to occur.

I've changed the `_repeatPauseTimer` to be nullable. This allows the `Timer` to be null and also be safely disposed.