### PR TITLE
glowRepeatCount variable added to repeat animation a specific number of times

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ AvatarGlow(
   glowShape: BoxShape.circle,
   animate: _animate,
   curve: Curves.fastOutSlowIn,
+  glowRepeatCount: 5   // Animation will be repeated 5 times
   child: const Material(
     elevation: 8.0,
     shape: CircleBorder(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -118,6 +118,7 @@ class _HomePageState extends State<HomePage> {
           const SizedBox(height: 32.0),
           AvatarGlow(
             animate: _animate,
+            glowRepeatCount: 5,
             glowColor: Colors.cyan,
             child: Material(
               elevation: 8.0,

--- a/lib/src/avatar_glow.dart
+++ b/lib/src/avatar_glow.dart
@@ -19,6 +19,7 @@ class AvatarGlow extends StatefulWidget {
     this.repeat = true,
     this.curve = Curves.fastOutSlowIn,
     this.glowRadiusFactor = 0.7,
+    this.glowRepeatCount = -1
   })  : assert(
           glowShape != BoxShape.circle || glowBorderRadius == null,
           'Cannot specify a border radius if the shape is a circle.',
@@ -58,6 +59,9 @@ class AvatarGlow extends StatefulWidget {
   /// The factor that determines the size of each glow effect relative to the original size.
   final double glowRadiusFactor;
 
+  /// Number of times glowing animation should be repeated
+  final int glowRepeatCount;
+
   @override
   State<AvatarGlow> createState() => _AvatarGlowState();
 }
@@ -76,11 +80,24 @@ class _AvatarGlowState extends State<AvatarGlow>
 
     // Check if the widget is still mounted before starting the animation.
     if (mounted) {
-      if (widget.repeat) {
-        _controller.repeat();
+      if (widget.glowRepeatCount > 0) {
+        TickerFuture tickerFuture = _controller.repeat();
+        tickerFuture.timeout(widget.duration * widget.glowRepeatCount,
+            onTimeout: () {
+          _controller.forward(from: 0);
+          _controller.stop(canceled: true);
+        });
       } else {
-        _controller.forward();
+        _manageController();
       }
+    }
+  }
+
+  void _manageController() {
+    if (widget.repeat) {
+      _controller.repeat();
+    } else {
+      _controller.forward();
     }
   }
 
@@ -125,11 +142,7 @@ class _AvatarGlowState extends State<AvatarGlow>
     }
 
     if (widget.repeat != oldWidget.repeat) {
-      if (widget.repeat) {
-        _controller.repeat();
-      } else {
-        _controller.forward();
-      }
+      _manageController();
     }
   }
 


### PR DESCRIPTION
The animation will be repeated 5 times as glowRepeatCount is set to 5. If this value is not passed then it will have existing behaviour.

Code:

```
AvatarGlow(
        animate: _animate,
        glowRepeatCount: 5,
        glowColor: Colors.cyan,
        child: Material(
          elevation: 8.0,
          shape: const CircleBorder(),
          child: CircleAvatar(
            backgroundColor: Colors.grey[100],
            radius: 30.0,
            child: Image.asset(
              'assets/images/dart.png',
              height: 50,
            ),
          ),
        ),
      )
```
      

https://github.com/apgapg/avatar_glow/assets/13239043/2029e508-6f5d-467c-9e55-add99d568ee7


      
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore